### PR TITLE
Removed unused and deprecated import. Refs #1

### DIFF
--- a/src/main/java/de/ustutt/iaas/bpmn2bpel/model/param/TopologyParameter.java
+++ b/src/main/java/de/ustutt/iaas/bpmn2bpel/model/param/TopologyParameter.java
@@ -2,8 +2,6 @@ package de.ustutt.iaas.bpmn2bpel.model.param;
 
 import javax.xml.namespace.QName;
 
-import com.sun.xml.internal.ws.util.StringUtils;
-
 /**
  * Copyright 2015 IAAS University of Stuttgart <br>
  * <br>


### PR DESCRIPTION
Removed the deprecated and unused com.sun.xml import. Builds should now work with java 1.8.
Afaik javax.xml should be used for future tasks (as com.sun is deprecated and may be removed any time).
