### PR TITLE
test update and node_interface

### DIFF
--- a/src/main/java/de/ustutt/iaas/bpmn2bpel/parser/JsonKeys.java
+++ b/src/main/java/de/ustutt/iaas/bpmn2bpel/parser/JsonKeys.java
@@ -23,7 +23,7 @@ public interface JsonKeys {
 	
 	public static final String NODE_OPERATION = "node_operation";
 	
-	public static final String NODE_INTERFACE_NAME = "node_interface";
+	public static final String NODE_INTERFACE_NAME = "interface";
 	
 	public static final String CONNECTIONS = "connections";
 	

--- a/src/test/java/de/ustutt/iaas/bpmn2bpel/BpelPlanArtefactWriterTest.java
+++ b/src/test/java/de/ustutt/iaas/bpmn2bpel/BpelPlanArtefactWriterTest.java
@@ -9,6 +9,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 
 import org.junit.After;
 import org.junit.Before;
@@ -52,7 +53,7 @@ public class BpelPlanArtefactWriterTest {
 	@Test
 	public void testWritePlan() throws MalformedURLException, ParseException, URISyntaxException {
 		BPMN4JsonParser parser = new BPMN4JsonParser();
-		URI uri = new URI("file:C:/Users/wagnerse/Documents/OpenTOSCA/BPMN4TOSCA2BPEL/BPMN4TOSCA2BPEL/src/test/resources/bpmn4tosca/bppmn4tosca.json");
+		URI uri = Paths.get("src/test/resources/bpmn4tosca/bppmn4tosca.json").toUri();
 		//Path testBpmn4JsonFile = Paths.get("C:/temp/bpmn4tosca/bppmn4tosca.json");
 		ManagementFlow mngmtFlow = parser.parse(uri);
 		

--- a/src/test/java/de/ustutt/iaas/bpmn2bpel/JsonParserTest.java
+++ b/src/test/java/de/ustutt/iaas/bpmn2bpel/JsonParserTest.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -48,7 +49,7 @@ public class JsonParserTest {
 	@Test
 	public void testParse() throws MalformedURLException, ParseException, URISyntaxException {
 		BPMN4JsonParser parser = new BPMN4JsonParser();
-		URI uri = new URI("file:c:/temp/bpmn4tosca/bppmn4tosca.json");
+		URI uri = Paths.get("src/test/resources/bpmn4tosca/bppmn4tosca.json").toUri();
 		//Path testBpmn4JsonFile = Paths.get("C:/temp/bpmn4tosca/bppmn4tosca.json");
 		ManagementFlow actualFlow = parser.parse(uri);
 		ManagementFlow expectedFlow = createReferenceFlow();

--- a/src/test/resources/bpmn4tosca/bppmn4tosca.json
+++ b/src/test/resources/bpmn4tosca/bppmn4tosca.json
@@ -30,7 +30,7 @@
     },
     "type": "ToscaNodeManagementTask",
     "node_template": "AmazonEC2NodeTemplate",
-    "node_interface": "ec2Interface",
+    "interface": "ec2Interface",
     "connections": [
       "element38"
     ],
@@ -56,7 +56,7 @@
       "top": 347
     },
     "type": "ToscaNodeManagementTask",
-    "node_interface": "ubunutuInterface",
+    "interface": "ubunutuInterface",
     "node_template": "UbuntuNodeTemplate",
     "connections": [
       "element45"


### PR DESCRIPTION
I updated tests to not use absolute paths anymore, the test resource is now used directly.

Furthermore, I changed the name of the property "node_interface" to "interface" because that is the same name I used in the modeler. Test resources are updated as well.

Unfortunately, I was not able to run the tests. It failed when it tried to set the value of a TopologyParameter in l.183 in JsonParserTest.
After removing that error, some assertion still failed, ie the expected ID CreateVMAmazonEC2 was CreateAmazonEC2Task (l. 115 in JsonParserTest). This is related to l. 26 in the test resource "bppmn4tosca.json".